### PR TITLE
Add heuristic profile text parser with optional enrichers

### DIFF
--- a/app/agents/profile_reader.py
+++ b/app/agents/profile_reader.py
@@ -98,7 +98,9 @@
 #     return out
 
 # app/agents/profile_reader.py
-from typing import Dict, Any
+import re
+from typing import Dict, Any, Tuple
+
 from ..utils.num import as_int
 
 _BUDGET_KEYS = [
@@ -226,3 +228,242 @@ def normalize_profile(p: Dict[str, Any]) -> Dict[str, Any]:
         "raw_text": raw_text,
     }
     return out
+
+
+def _optional_hook(name: str):
+    """Return a callable enrichment hook from app_patches if available."""
+    try:
+        from app_patches import profile_reader_patch  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
+        return None
+    return getattr(profile_reader_patch, name, None)
+
+
+def parse_profile_text(text: str, mode: str) -> Tuple[Dict[str, Any], float]:
+    """Parse unstructured profile text into a normalized profile dict.
+
+    The parser first applies lightweight regex/keyword heuristics so that it
+    works in fully offline (``degraded``) deployments.  When optional hooks are
+    available we call them to enrich the extraction – for example
+    ``app_patches.profile_reader_patch.ml_enrich`` can attach ML classifiers for
+    higher fidelity attributes.
+    """
+
+    raw_text = text or ""
+    lower_text = raw_text.lower()
+
+    # Early fallback for empty payloads – still pass through normalizer to make
+    # sure we get consistent default values (e.g. languages).
+    if not raw_text.strip():
+        profile = normalize_profile({"raw_text": raw_text})
+        return profile, 0.0
+
+    extracted: Dict[str, Any] = {"raw_text": raw_text}
+    heur_hits = 0
+    heur_total = 0
+
+    def _record(field: str, value: Any, weight: float = 1.0) -> None:
+        nonlocal heur_hits
+        if value is None:
+            return
+        extracted[field] = value
+        heur_hits += weight
+
+    def _probe(weight: float = 1.0) -> None:
+        nonlocal heur_total
+        heur_total += weight
+
+    # --- City ---
+    _probe()
+    for city in [
+        "karachi",
+        "lahore",
+        "islamabad",
+        "rawalpindi",
+        "peshawar",
+        "multan",
+        "faisalabad",
+        "quetta",
+        "hyderabad",
+        "sialkot",
+    ]:
+        if re.search(rf"\b{re.escape(city)}\b", lower_text):
+            _record("city", city.title())
+            break
+
+    # --- Budget ---
+    _probe()
+    budget_val = None
+    budget_patterns = [
+        re.compile(r"(?:pkr|rs|rupees)?\s*([0-9][0-9,\.]{3,})\s*(?:/\s*mo|per month|monthly|pkr|rs|rupees)?"),
+        re.compile(r"([0-9]{2,})\s*[kK]\b"),
+    ]
+    for pat in budget_patterns:
+        match = pat.search(lower_text)
+        if not match:
+            continue
+        raw_num = match.group(1).replace(",", "").replace(".", "")
+        if raw_num.endswith("k") or raw_num.endswith("K"):
+            raw_num = raw_num[:-1]
+        as_num = as_int(raw_num)
+        if pat.pattern.endswith("[kK]\\b") and as_num is not None:
+            as_num *= 1000
+        if as_num:
+            budget_val = as_num
+            break
+    if budget_val is not None:
+        _record("budget", budget_val)
+
+    # --- Sleep schedule ---
+    _probe()
+    sleep_guess = None
+    for token in list(_SLEEP_MAP.keys()) + ["morning person", "night person"]:
+        if token in lower_text:
+            sleep_guess = _norm_enum(token, _SLEEP_MAP)
+            if not sleep_guess and token == "morning person":
+                sleep_guess = "early_bird"
+            if not sleep_guess and token == "night person":
+                sleep_guess = "night_owl"
+            if sleep_guess:
+                break
+    if sleep_guess:
+        _record("sleep_schedule", sleep_guess)
+
+    # --- Cleanliness ---
+    _probe()
+    clean_guess = None
+    if "neat" in lower_text or "tidy" in lower_text:
+        clean_guess = "high"
+    elif "messy" in lower_text or "laid back" in lower_text:
+        clean_guess = "low"
+    else:
+        for token in _CLEAN_MAP.keys():
+            if token in lower_text:
+                clean_guess = _norm_enum(token, _CLEAN_MAP)
+                break
+    if clean_guess:
+        _record("cleanliness", clean_guess)
+
+    # --- Noise tolerance ---
+    _probe()
+    noise_guess = None
+    if "quiet" in lower_text or "silence" in lower_text:
+        noise_guess = "low"
+    elif "party" in lower_text or "music" in lower_text:
+        noise_guess = "high"
+    else:
+        for token in _NOISE_MAP.keys():
+            if token in lower_text:
+                noise_guess = _norm_enum(token, _NOISE_MAP)
+                break
+    if noise_guess:
+        _record("noise_tolerance", noise_guess)
+
+    # --- Guests frequency ---
+    _probe()
+    guests_guess = None
+    if "guests" in lower_text:
+        for token in _GUESTS_MAP.keys():
+            if token in lower_text:
+                guests_guess = _norm_enum(token, _GUESTS_MAP)
+                break
+        if not guests_guess and "weekend" in lower_text:
+            guests_guess = "sometimes"
+    if guests_guess:
+        _record("guests_freq", guests_guess)
+
+    # --- Smoking ---
+    _probe()
+    smoking = None
+    if "non smoker" in lower_text or "non-smoker" in lower_text or "don't smoke" in lower_text:
+        smoking = "no"
+    elif "smoker" in lower_text or "smoke" in lower_text:
+        smoking = "yes"
+    if smoking:
+        _record("smoking", smoking)
+
+    # --- Role ---
+    _probe()
+    role_guess = None
+    for token in _ROLE_MAP.keys():
+        if token in lower_text:
+            role_guess = _norm_enum(token, _ROLE_MAP) or token
+            break
+    if not role_guess:
+        if "study" in lower_text or "semester" in lower_text:
+            role_guess = "student"
+        elif "office" in lower_text or "work" in lower_text:
+            role_guess = "professional"
+    if role_guess:
+        _record("role", role_guess)
+
+    # --- Food preferences ---
+    _probe(0.5)
+    food_guess = None
+    if "vegetarian" in lower_text or "vegan" in lower_text:
+        food_guess = "vegetarian"
+    elif "halal" in lower_text:
+        food_guess = "halal"
+    elif "non veg" in lower_text or "non-veg" in lower_text:
+        food_guess = "non_veg"
+    if food_guess:
+        _record("food_pref", food_guess, weight=0.5)
+
+    # --- Language hints ---
+    language_hits = []
+    for lang, tokens in {
+        "ur": ["urdu"],
+        "en": ["english"],
+        "pa": ["punjabi"],
+        "ps": ["pashto"],
+    }.items():
+        if any(tok in lower_text for tok in tokens):
+            language_hits.append(lang)
+    if language_hits:
+        extracted["languages"] = sorted(set(language_hits))
+
+    # Optional regex enrich hook (e.g., app_patches.profile_reader_patch.regex_enrich)
+    regex_hook = _optional_hook("regex_enrich")
+    if callable(regex_hook):
+        try:
+            enriched = regex_hook(dict(extracted))
+            if isinstance(enriched, dict):
+                extracted.update(enriched)
+        except Exception:
+            pass
+
+    # Optional ML enrich hook. Skip when running in degraded mode to avoid
+    # depending on heavy models or remote services.
+    if mode != "degraded":
+        ml_hook = _optional_hook("ml_enrich")
+        if callable(ml_hook):
+            try:
+                enriched = ml_hook(dict(extracted))
+                if isinstance(enriched, dict):
+                    extracted.update(enriched)
+            except Exception:
+                pass
+
+    normalized = normalize_profile(extracted)
+
+    coverage_fields = [
+        "city",
+        "budget_pkr",
+        "sleep_schedule",
+        "cleanliness",
+        "noise_tolerance",
+        "smoking",
+        "guests_freq",
+        "role",
+        "food_pref",
+    ]
+    coverage = sum(1 for f in coverage_fields if normalized.get(f))
+    coverage_ratio = coverage / len(coverage_fields)
+    heur_ratio = heur_hits / heur_total if heur_total else 0.0
+
+    confidence = 0.2 + 0.5 * heur_ratio + 0.3 * coverage_ratio
+    if mode == "degraded":
+        confidence *= 0.9
+    confidence = max(0.0, min(0.99, round(confidence, 3)))
+
+    return normalized, confidence

--- a/app/main.py
+++ b/app/main.py
@@ -254,6 +254,30 @@ def healthz():
 
 @app.post("/profiles/parse")
 def parse_profile(req: ParseReq, x_mode: Optional[str] = Header(None)):
+    """Parse freeform roommate text into structured attributes.
+
+    Example response::
+
+        {
+            "profile": {
+                "city": "Lahore",
+                "budget_pkr": 35000,
+                "sleep_schedule": "night_owl",
+                "cleanliness": "medium",
+                "noise_tolerance": "medium",
+                "smoking": "no",
+                "guests_freq": "sometimes",
+                "role": "student",
+                "languages": ["en", "ur"],
+                "raw_text": "..."
+            },
+            "confidence": 0.72,
+            "mode_used": "online"
+        }
+
+    Confidence is a heuristic between 0 and 1 describing how sure the parser is
+    about the extracted attributes.
+    """
     mode = _mode(req.mode, x_mode)
     from .agents.profile_reader import parse_profile_text
     prof, conf = parse_profile_text(req.text, mode=mode)


### PR DESCRIPTION
## Summary
- implement parse_profile_text to extract roommate attributes using regex heuristics and optional enrichment hooks
- normalize parsed values with existing helpers and compute a confidence score resilient to degraded mode
- document the /profiles/parse endpoint with an example response highlighting the new parser output

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68dcf431603c832393ecea70c5651375