### PR TITLE
Add amenity-aware room suggestion helper

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -154,6 +154,7 @@ from pydantic import BaseModel
 
 from .graph import run_pipeline
 from .services.firestore import fetch_all_profiles, fetch_all_listings
+from .agents.room_hunter import suggest_rooms
 
 
 SERVER_DEFAULT_MODE = os.getenv("MODE", "online").lower()
@@ -234,6 +235,8 @@ class RoomSuggestReq(BaseModel):
     per_person_budget: int
     needed_amenities: List[str] = []
     mode: Optional[str] = None
+    anchor_location: Optional[Dict[str, Any]] = None
+    geo: Optional[Dict[str, Any]] = None
 
 
 # ---------------- Endpoints ----------------
@@ -282,6 +285,14 @@ def match_top(req: MatchTopReq, x_mode: Optional[str] = Header(None)):
 def rooms_suggest(req: RoomSuggestReq, x_mode: Optional[str] = Header(None)):
     mode = _mode(req.mode, x_mode)
     _load_cached()
-    from .agents.room_hunter import suggest_rooms
-    out = suggest_rooms(req.city, req.per_person_budget, req.needed_amenities, _listings_cache, mode=mode, limit=5)
+    out = suggest_rooms(
+        req.city,
+        req.per_person_budget,
+        req.needed_amenities,
+        _listings_cache,
+        mode=mode,
+        limit=5,
+        anchor_location=req.anchor_location,
+        user_geo=req.geo,
+    )
     return {"listings": out, "mode_used": mode}


### PR DESCRIPTION
## Summary
- add a `suggest_rooms` helper that filters listings by amenities, calls `rank_rooms`, and optionally enriches results with commute data
- extend the `/rooms/suggest` request schema to accept user anchor/geolocation and delegate to the new helper from the FastAPI endpoint

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_b_68dcfd7597c4832384e8f343ecd3a002