### PR TITLE
Enhance anchor commute severity and wingman coaching

### DIFF
--- a/app/agents/wingman.py
+++ b/app/agents/wingman.py
@@ -31,61 +31,83 @@
 #     return clean
 
 # app/agents/wingman.py
-from typing import List, Dict
+from typing import List, Dict, Any
+
 
 def wingman(reasons: List[str], flags: List[Dict], profile: Dict = None, other: Dict = None) -> List[str]:
-    """
-    Generate friendly tips based on match reasons, conflicts, and profile context.
-    """
+    """Generate friendly tips based on match reasons, conflicts, and profile context."""
+
     tips: List[str] = []
+    seen: set[str] = set()
+
+    def _clean(text: str) -> str:
+        return (text or "").replace("—", "-").replace("–", "-").replace("±", "+/-")
+
+    def _norm_key(text: str) -> str:
+        return " ".join((text or "").lower().split())
+
+    def _add_tip(text: str) -> None:
+        key = _norm_key(text)
+        if not key or key in seen:
+            return
+        seen.add(key)
+        tips.append(_clean(text))
 
     # ---------------- Positive nudges ----------------
-    if any("same city" in r.lower() for r in reasons):
-        tips.append("You're in the same city - logistics are easy.")
-    if any("budget" in r.lower() for r in reasons):
-        tips.append("Budgets align - split rent fairly and track utilities.")
+    if any("same city" in (r or "").lower() for r in reasons):
+        _add_tip("You're in the same city - logistics are easy.")
+    if any("budget" in (r or "").lower() for r in reasons):
+        _add_tip("Budgets align - split rent fairly and track utilities.")
+
+    # ---------------- Anchor context ----------------
+    def _anchor_label(anchor: Dict[str, Any] | None) -> str:
+        if not isinstance(anchor, dict):
+            return ""
+        return anchor.get("label") or anchor.get("name") or ""
+
+    anchor_a = _anchor_label((profile or {}).get("anchor_location"))
+    anchor_b = _anchor_label((other or {}).get("anchor_location"))
+    if anchor_a and anchor_b:
+        _add_tip(
+            f"Anchors spotted: you're near {anchor_a}, they're near {anchor_b} — align commute expectations early."
+        )
+    elif any("anchor" in (r or "").lower() for r in reasons):
+        _add_tip("💡 Easy commute - you're both anchored in the same area.")
 
     # ---------------- Role-based tips ----------------
-    if profile and other:
-        role_a, role_b = profile.get("role"), other.get("role")
-        if role_a and role_b:
-            if role_a == "student" and role_b == "student":
-                tips.append("💡 Plan shared study hours or library sessions.")
-            elif role_a == "professional" and role_b == "professional":
-                tips.append("💡 Share commute costs or coordinate office timings.")
-            elif {role_a, role_b} == {"student", "professional"}:
-                tips.append("💡 Respect different routines: classes vs office work.")
-
-    # ---------------- Anchor-based tips ----------------
-    if reasons:
-        for r in reasons:
-            if "anchor" in r.lower() or "same anchor" in r.lower() or "close" in r.lower():
-                tips.append("💡 Easy commute - you’re both anchored in the same area.")
+    role_a = (profile or {}).get("role")
+    role_b = (other or {}).get("role")
+    if role_a and role_b:
+        if role_a == "student" and role_b == "student":
+            _add_tip("Study buddies? Set shared quiet study blocks and celebrate wins together.")
+        elif role_a == "professional" and role_b == "professional":
+            _add_tip("Two professionals: align on work-from-home days and split ride-share costs.")
+        elif {role_a, role_b} == {"student", "professional"}:
+            _add_tip("Mixed routines: share class schedules and office hours to prevent noise clashes.")
 
     # ---------------- Conflict resolutions ----------------
+    mitigation_map = {
+        "sleep_vs_guests": "Set quiet hours (10pm-7am) and keep hosting to weekends.",
+        "cleanliness_mismatch": "Use a weekly cleaning rota and a shared supplies list.",
+        "smoking_clash": "Keep indoor smoke-free; designate an outdoor smoking spot.",
+        "anchor_too_far": "⚠️ Anchors are far apart — budget for transport or consider a midpoint.",
+        "anchor_city_mismatch": "⚠️ Different anchor cities — agree on long-term plans before committing.",
+        "anchor_commute_heavy": "Commute is heavy — explore ride-shares or alternating WFH days.",
+        "anchor_commute_notice": "Test the commute at rush hour so surprises stay low.",
+        "role_lifestyle_gap": "Sync weekly routines: post a shared calendar for classes, work shifts, and quiet hours.",
+    }
+
     for f in flags or []:
         t = (f.get("type") or "").lower() if isinstance(f, dict) else str(f).lower()
-        if t == "sleep_vs_guests":
-            tips.append("Set quiet hours (10pm-7am) and keep hosting to weekends.")
-        elif t == "cleanliness_mismatch":
-            tips.append("Use a weekly cleaning rota and a shared supplies list.")
-        elif t == "smoking_clash":
-            tips.append("Keep indoor smoke-free; designate an outdoor smoking spot.")
-        elif t == "anchor_too_far":
-            tips.append("⚠️ Anchors are far apart - consider transport or relocation options.")
-        elif t == "anchor_city_mismatch":
-            tips.append("⚠️ Different anchor cities - this may not be practical long-term.")
-        elif t:
-            tips.append(f"Address potential issue: {t}")
+        if not t:
+            continue
+        if t in mitigation_map:
+            _add_tip(mitigation_map[t])
+        else:
+            _add_tip(f"Address potential issue: {t}")
 
     # ---------------- Default fallback ----------------
     if not tips:
-        tips.append("Looks compatible - align on groceries, utilities split, and quiet hours early.")
+        _add_tip("Looks compatible - align on groceries, utilities split, and quiet hours early.")
 
-    # Normalize fancy unicode dashes
-    clean = []
-    for t in tips:
-        t2 = (t or "").replace("—", "-").replace("–", "-").replace("±", "+/-")
-        clean.append(t2)
-
-    return clean
+    return tips

--- a/frontend/widget/index.html
+++ b/frontend/widget/index.html
@@ -8,7 +8,7 @@
     <h1>Widget Dev Preview</h1>
     <div id="room-matcher"></div>
     <script type="module">
-      import { mount } from "./src/mount.tsx";
+      import { mount } from "./src/Mount.tsx";
       mount("#room-matcher", { apiBase: "http://127.0.0.1:8082" });
     </script>
   </body>

--- a/frontend/widget/src/Mount.tsx
+++ b/frontend/widget/src/Mount.tsx
@@ -1,4 +1,4 @@
-// frontend/widget/src/mount.tsx
+// frontend/widget/src/Mount.tsx
 import React from "react";
 import ReactDOM from "react-dom/client";
 import RoomMatcherWidget, { RoomMatcherWidgetProps } from "./RoomMatcherWidget";
@@ -10,6 +10,8 @@ export function mount(selectorOrEl: string | Element, props?: RoomMatcherWidgetP
   const root = ReactDOM.createRoot(el as Element);
   root.render(<RoomMatcherWidget {...props} />);
 }
+
+export type { RoomMatcherWidgetProps };
 
 // provide global for <script> usage
 declare global {

--- a/frontend/widget/src/RoomMatcherWidget.tsx
+++ b/frontend/widget/src/RoomMatcherWidget.tsx
@@ -1,5 +1,5 @@
 // frontend/widget/src/RoomMatcherWidget.tsx
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 
 // 👇 Props match backend inputs
 export interface RoomMatcherWidgetProps {
@@ -51,6 +51,16 @@ export default function RoomMatcherWidget({
     const data = await res.json();
     setResult(data);
   }
+
+  const severityPill = useMemo(
+    () =>
+      ({
+        high: { bg: "#7f1d1d", text: "#fecaca", label: "High" },
+        medium: { bg: "#78350f", text: "#fde68a", label: "Medium" },
+        low: { bg: "#1f2937", text: "#fef3c7", label: "Low" }
+      } as const),
+    []
+  );
 
   // ---------------- UI ----------------
   return (
@@ -140,21 +150,74 @@ export default function RoomMatcherWidget({
                 marginBottom: "0.5rem"
               }}
             >
-              <b>Profile {m.other_profile_id}</b> — Score {m.score}
-              <div style={{ fontSize: "0.8rem", color: "#555" }}>
+              <div style={{ display: "flex", justifyContent: "space-between" }}>
+                <b>Profile {m.other_profile_id}</b>
+                <span style={{ fontSize: "0.8rem", color: "#0f172a", fontWeight: 600 }}>
+                  Score {m.score}
+                </span>
+              </div>
+              <div style={{ fontSize: "0.8rem", color: "#555", marginTop: "0.25rem" }}>
                 {m.reasons?.join(" • ")}
               </div>
               {m.conflicts?.length > 0 && (
-                <div style={{ fontSize: "0.8rem", color: "red" }}>
-                  ⚠ Conflicts:{" "}
-                  {m.conflicts.map((f: any) => f.details || f.type).join(", ")}
+                <div style={{ marginTop: "0.5rem", display: "grid", gap: "0.35rem" }}>
+                  {m.conflicts.map((f: any, idx: number) => {
+                    const sev = severityPill[(f.severity || "low").toLowerCase() as keyof typeof severityPill];
+                    return (
+                      <div
+                        key={`${f.type}-${idx}`}
+                        style={{
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: "0.25rem",
+                          borderLeft: `4px solid ${sev?.bg ?? "#1f2937"}`,
+                          paddingLeft: "0.5rem"
+                        }}
+                      >
+                        <div style={{ display: "flex", alignItems: "center", gap: "0.35rem" }}>
+                          <span
+                            style={{
+                              background: sev?.bg ?? "#1f2937",
+                              color: sev?.text ?? "#fff7ed",
+                              borderRadius: "999px",
+                              fontSize: "0.65rem",
+                              padding: "0.15rem 0.5rem",
+                              textTransform: "uppercase",
+                              letterSpacing: "0.05em"
+                            }}
+                          >
+                            {sev?.label ?? (f.severity || "Low")}
+                          </span>
+                          <strong style={{ fontSize: "0.75rem", color: "#7f1d1d" }}>
+                            {f.type?.replace(/_/g, " ")}
+                          </strong>
+                        </div>
+                        <span style={{ fontSize: "0.75rem", color: "#374151" }}>
+                          {f.details || "Needs attention"}
+                        </span>
+                      </div>
+                    );
+                  })}
                 </div>
               )}
-              {m.tips?.map((t: string, idx: number) => (
-                <div key={idx} style={{ fontSize: "0.75rem" }}>
-                  💡 {t}
+              {m.tips?.length > 0 && (
+                <div style={{ marginTop: "0.5rem", display: "grid", gap: "0.25rem" }}>
+                  {m.tips.map((t: string, idx: number) => (
+                    <div
+                      key={idx}
+                      style={{
+                        fontSize: "0.75rem",
+                        background: "#f8fafc",
+                        borderRadius: "0.35rem",
+                        padding: "0.35rem",
+                        color: "#0f172a"
+                      }}
+                    >
+                      💡 {t}
+                    </div>
+                  ))}
                 </div>
-              ))}
+              )}
             </div>
           ))}
 

--- a/tests/test_red_flags.py
+++ b/tests/test_red_flags.py
@@ -1,0 +1,64 @@
+import unittest
+
+from app.agents.red_flag import red_flags
+
+
+class RedFlagRuleTests(unittest.TestCase):
+    def _anchors(self, lat_a, lon_a, lat_b, lon_b, label_a="Campus", label_b="Tech Park"):
+        a = {
+            "role": "student",
+            "anchor_location": {"lat": lat_a, "lng": lon_a, "label": label_a},
+        }
+        b = {
+            "role": "professional",
+            "anchor_location": {"lat": lat_b, "lng": lon_b, "label": label_b},
+        }
+        return red_flags(a, b)
+
+    def test_role_lifestyle_gap_flagged_with_medium_severity(self):
+        flags = red_flags(
+            {"role": "student"},
+            {"role": "professional"},
+        )
+        role_flags = [f for f in flags if f["type"] == "role_lifestyle_gap"]
+        self.assertTrue(role_flags, "Expected role_lifestyle_gap flag to trigger")
+        self.assertTrue(all(f["severity"] == "medium" for f in role_flags))
+        self.assertTrue(any("student" in f["details"].lower() for f in role_flags))
+
+    def test_anchor_commute_notice_low_severity(self):
+        # ~15 km apart
+        flags = self._anchors(31.5, 74.3, 31.63, 74.45)
+        commute_flag = next(f for f in flags if f["type"] == "anchor_commute_notice")
+        self.assertEqual(commute_flag["severity"], "low")
+        self.assertIn("PKR", commute_flag["details"])
+
+    def test_anchor_commute_heavy_medium_severity(self):
+        # ~26 km apart
+        flags = self._anchors(31.5, 74.3, 31.74, 74.34)
+        commute_flag = next(f for f in flags if f["type"] == "anchor_commute_heavy")
+        self.assertEqual(commute_flag["severity"], "medium")
+        self.assertIn("PKR", commute_flag["details"])
+
+    def test_anchor_too_far_high_severity(self):
+        # ~75 km apart
+        flags = self._anchors(31.5, 74.3, 32.1, 75.2)
+        commute_flag = next(f for f in flags if f["type"] == "anchor_too_far")
+        self.assertEqual(commute_flag["severity"], "high")
+        self.assertIn("PKR", commute_flag["details"])
+
+    def test_anchor_city_mismatch_uses_labels(self):
+        flags = red_flags(
+            {
+                "anchor_location": {"lat": 31.5, "lng": 74.3, "label": "Lahore, PK"},
+            },
+            {
+                "anchor_location": {"lat": 33.7, "lng": 73.1, "label": "Islamabad, PK"},
+            },
+        )
+        city_flags = [f for f in flags if f["type"] == "anchor_city_mismatch"]
+        self.assertTrue(city_flags)
+        self.assertTrue(all("lahore" in f["details"].lower() for f in city_flags))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wingman.py
+++ b/tests/test_wingman.py
@@ -1,0 +1,29 @@
+import unittest
+
+from app.agents.wingman import wingman
+
+
+class WingmanTipTests(unittest.TestCase):
+    def test_deduplication_and_anchor_role_tips(self):
+        reasons = ["Great same city vibes", "Anchor overlap", "Anchor overlap"]
+        flags = [
+            {"type": "role_lifestyle_gap"},
+            {"type": "anchor_commute_heavy"},
+            {"type": "anchor_commute_heavy"},
+        ]
+        profile = {"role": "student", "anchor_location": {"label": "FAST NUCES"}}
+        other = {"role": "professional", "anchor_location": {"label": "Packages Mall"}}
+
+        tips = wingman(reasons, flags, profile=profile, other=other)
+
+        self.assertEqual(len(tips), len(set(tips)), "Wingman tips should be de-duplicated")
+        self.assertTrue(any("FAST NUCES" in t for t in tips), "Anchor labels should be surfaced")
+        self.assertTrue(any("commute" in t.lower() for t in tips), "Commute mitigation should appear")
+        self.assertTrue(
+            any("calendar" in t.lower() or "routines" in t.lower() for t in tips),
+            "Role lifestyle gap mitigation expected",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add role lifestyle gaps and anchor commute severity tiers with cost estimates to the red flag detector
- enrich wingman guidance with anchor labels, role prep tips, and per-flag mitigation while de-duplicating suggestions
- refresh the widget rendering to visualize conflict severities and add unit tests covering the new rules

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_b_68dd0529e464832385bcdec1f44aeec2