### PR TITLE
Add asynchronous auto-hunt watcher with notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,31 @@ Install deps:
 pip install -r requirements.txt
 ```
 
+### 2. Auto-Hunt background workers (optional)
+
+`app/agents/watcher.py` now runs through a Celery worker. To enable asynchronous
+auto-hunt notifications set the broker/backend and start the worker alongside
+FastAPI:
+
+```bash
+export CELERY_BROKER_URL=redis://localhost:6379/0
+export CELERY_RESULT_BACKEND=redis://localhost:6379/0
+
+celery -A app.services.task_queue.celery_app worker --loglevel=info
+```
+
+Configuration knobs can be tuned via environment variables or Firestore
+documents in the `watcher_configs` collection:
+
+- `AUTO_HUNT_DEFAULT_CADENCE_SEC` – polling cadence (default `900` seconds)
+- `AUTO_HUNT_DEFAULT_MIN_SCORE` – minimum score required to notify
+- `AUTO_HUNT_DEFAULT_TOP_K` – number of matches pulled each cycle
+- `AUTO_HUNT_DEFAULT_CHANNELS` – comma separated list of channels (`email`,
+  `sms`, `webhook`)
+
+Firestore overrides support partner specific channels/webhooks and allow
+per-institution cadences without re-deploying the backend.
+
 ---
 
 ## 🧪 Profile Matching Evaluation Harness

--- a/app/agents/watcher.py
+++ b/app/agents/watcher.py
@@ -1,16 +1,234 @@
-import time
-from app.services.firestore import fetch_all_profiles, fetch_all_listings
-from app.graph import run_pipeline
+from __future__ import annotations
 
-def auto_hunt(user_profile: dict, interval: int = 300):
+import hashlib
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from app.graph import run_pipeline
+from app.services.firestore import (
+    fetch_all_listings,
+    fetch_all_profiles,
+    fetch_notified_matches,
+    fetch_watcher_config,
+    store_notified_matches,
+)
+from app.services.notifier import NotificationPayload, Notifier
+from app.services.task_queue import celery_app
+from app.agents.match_scorer import MatchScoreConfig
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _default_cadence() -> int:
+    return int(os.getenv("AUTO_HUNT_DEFAULT_CADENCE_SEC", "900"))
+
+
+def _default_min_score() -> int:
+    return int(os.getenv("AUTO_HUNT_DEFAULT_MIN_SCORE", "55"))
+
+
+def _default_top_k() -> int:
+    return int(os.getenv("AUTO_HUNT_DEFAULT_TOP_K", "5"))
+
+
+def _default_channels() -> List[str]:
+    raw = os.getenv("AUTO_HUNT_DEFAULT_CHANNELS", "email")
+    return [c.strip() for c in raw.split(",") if c.strip()]
+
+
+def _use_async() -> bool:
+    if os.getenv("AUTO_HUNT_FORCE_SYNC", "false").lower() == "true":
+        return False
+    return bool(os.getenv("CELERY_BROKER_URL"))
+
+
+def _scope_from_profile(user_profile: Dict[str, Any], institution_id: Optional[str]) -> str:
+    return (
+        institution_id
+        or user_profile.get("institution_id")
+        or user_profile.get("campus")
+        or user_profile.get("organization")
+        or "default"
+    )
+
+
+def profile_key(user_profile: Dict[str, Any]) -> str:
+    """Stable identifier for watcher state storage."""
+
+    for field in ("id", "profile_id", "email", "phone", "phone_number"):
+        if user_profile.get(field):
+            return str(user_profile[field])
+    digest = hashlib.sha1(str(sorted(user_profile.items())).encode("utf-8")).hexdigest()
+    return f"anon-{digest}"
+
+
+@dataclass
+class WatcherConfig:
+    cadence_sec: int = field(default_factory=_default_cadence)
+    min_score: int = field(default_factory=_default_min_score)
+    top_k: int = field(default_factory=_default_top_k)
+    channels: List[str] = field(default_factory=_default_channels)
+    partner_webhooks: List[str] = field(default_factory=list)
+    match_config: Optional[Dict[str, Any]] = None
+
+    @classmethod
+    def from_dict(cls, payload: Optional[Dict[str, Any]]) -> "WatcherConfig":
+        if not payload:
+            return cls()
+        return cls(
+            cadence_sec=int(payload.get("cadence_sec", _default_cadence())),
+            min_score=int(payload.get("min_score", _default_min_score())),
+            top_k=int(payload.get("top_k", _default_top_k())),
+            channels=list(payload.get("channels") or _default_channels()),
+            partner_webhooks=list(payload.get("partner_webhooks", []) or []),
+            match_config=payload.get("match_config"),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "cadence_sec": self.cadence_sec,
+            "min_score": self.min_score,
+            "top_k": self.top_k,
+            "channels": list(self.channels),
+            "partner_webhooks": list(self.partner_webhooks),
+            "match_config": self.match_config,
+        }
+
+
+def get_watcher_config(user_profile: Dict[str, Any], institution_id: Optional[str] = None) -> WatcherConfig:
+    scope = _scope_from_profile(user_profile, institution_id)
+    overrides = fetch_watcher_config(scope)
+    return WatcherConfig.from_dict(overrides)
+
+
+def _build_match_config(config: Optional[Dict[str, Any]]) -> Optional[MatchScoreConfig]:
+    if not config:
+        return None
+    weights = config.get("weights")
+    anchor_buckets = config.get("anchor_buckets")
+    kwargs: Dict[str, Any] = {}
+    if weights:
+        kwargs["weights"] = dict(weights)
+    if anchor_buckets:
+        kwargs["anchor_buckets"] = tuple(tuple(bucket) for bucket in anchor_buckets)
+    return MatchScoreConfig(**kwargs)
+
+
+def _run_auto_hunt_cycle(
+    user_profile: Dict[str, Any],
+    scope: str,
+    config: WatcherConfig,
+) -> Dict[str, Any]:
+    profiles = fetch_all_profiles()
+    listings = fetch_all_listings()
+
+    key = profile_key(user_profile)
+    previously_notified = set(fetch_notified_matches(scope, key))
+
+    pipeline_result = run_pipeline(
+        user_profile,
+        profiles,
+        listings,
+        mode="online",
+        top_k=config.top_k,
+        match_config=_build_match_config(config.match_config),
+        notified_match_ids=previously_notified,
+    )
+
+    matches = pipeline_result.get("matches", [])
+    new_matches = [m for m in matches if m.get("is_new") and (m.get("score") or 0) >= config.min_score]
+
+    notifier = Notifier()
+    payload = NotificationPayload(
+        scope=scope,
+        user_profile=user_profile,
+        matches=new_matches,
+        rooms=pipeline_result.get("rooms", []),
+        trace=pipeline_result.get("trace", {}),
+        metadata={"min_score": config.min_score, "top_k": config.top_k},
+    )
+
+    channel_results: Dict[str, Any] = {}
+    if new_matches:
+        LOGGER.info("Dispatching notifications for %s (scope=%s)", key, scope)
+        channel_results = notifier.dispatch(payload, config.channels, config.partner_webhooks)
+        previously_notified.update(m.get("other_profile_id") for m in new_matches if m.get("other_profile_id"))
+        store_notified_matches(scope, key, sorted(previously_notified))
+    else:
+        LOGGER.info("No new matches for %s (scope=%s)", key, scope)
+
+    return {
+        "config": config.to_dict(),
+        "result": pipeline_result,
+        "new_matches": new_matches,
+        "notifications": channel_results,
+        "scope": scope,
+        "profile_key": key,
+    }
+
+
+@celery_app.task(name="watcher.auto_hunt", bind=True)
+def run_auto_hunt_task(self, user_profile: Dict[str, Any], scope: str, config_override: Optional[Dict[str, Any]] = None, reschedule: bool = True) -> Dict[str, Any]:
+    config = WatcherConfig.from_dict(config_override)
+    outcome = _run_auto_hunt_cycle(user_profile, scope, config)
+
+    if reschedule and config.cadence_sec > 0:
+        LOGGER.debug("Scheduling next auto-hunt run for %s in %s seconds", outcome["profile_key"], config.cadence_sec)
+        run_auto_hunt_task.apply_async(
+            kwargs={
+                "user_profile": user_profile,
+                "scope": scope,
+                "config_override": config.to_dict(),
+            },
+            countdown=config.cadence_sec,
+        )
+
+    return outcome
+
+
+def auto_hunt(
+    user_profile: Dict[str, Any],
+    institution_id: Optional[str] = None,
+    reschedule: bool = True,
+) -> Any:
+    """Schedule the auto-hunt background job for a user.
+
+    When a Celery broker is configured, the job is enqueued asynchronously.  In
+    development (or tests) without Celery the pipeline runs synchronously to
+    preserve backwards compatibility.
     """
-    Periodically re-run pipeline for a user and print/notify new matches.
-    In production: hook into Gmail/Calendar APIs for notifications.
-    """
-    while True:
-        print("⏳ Auto-Hunt running...")
-        profiles = fetch_all_profiles()
-        listings = fetch_all_listings()
-        result = run_pipeline(user_profile, profiles, listings, mode="online", top_k=5)
-        print("Top match:", result["matches"][0] if result["matches"] else "None")
-        time.sleep(interval)
+
+    scope = _scope_from_profile(user_profile, institution_id)
+    config = get_watcher_config(user_profile, institution_id)
+
+    if _use_async():
+        LOGGER.info("Queueing auto-hunt task for scope=%s profile=%s", scope, profile_key(user_profile))
+        result = run_auto_hunt_task.apply_async(
+            kwargs={
+                "user_profile": user_profile,
+                "scope": scope,
+                "config_override": config.to_dict(),
+                "reschedule": reschedule,
+            }
+        )
+        return result.id
+
+    LOGGER.info("Running auto-hunt synchronously for scope=%s profile=%s", scope, profile_key(user_profile))
+    return run_auto_hunt_task.run(
+        user_profile=user_profile,
+        scope=scope,
+        config_override=config.to_dict(),
+        reschedule=reschedule,
+    )
+
+
+__all__ = [
+    "auto_hunt",
+    "get_watcher_config",
+    "profile_key",
+    "run_auto_hunt_task",
+    "WatcherConfig",
+]

--- a/app/services/firestore.py
+++ b/app/services/firestore.py
@@ -1,9 +1,14 @@
 import os
-from typing import List, Dict, Optional
+import threading
+from typing import List, Dict, Optional, Tuple, Any
 from app.agents.profile_reader import normalize_profile
 
 USE_FIRESTORE = os.getenv("FIRESTORE_ENABLED", "false").lower() == "true"
 PROJECT_ID = os.getenv("GCP_PROJECT")
+
+_CONFIG_LOCK = threading.Lock()
+_LOCAL_CONFIG_CACHE: Dict[str, Dict[str, Any]] = {}
+_LOCAL_NOTIFIED_CACHE: Dict[Tuple[str, str], List[str]] = {}
 
 def _client():
     from google.cloud import firestore
@@ -49,6 +54,105 @@ def fetch_all_listings() -> List[Dict]:
     db = _client()
     docs = db.collection("listings").stream()
     return [d.to_dict() for d in docs]
+
+
+# -------------------------------
+# Watcher configuration + state
+# -------------------------------
+
+def fetch_watcher_config(scope: str) -> Dict[str, Any]:
+    """Return watcher configuration for a tenant/institution scope."""
+
+    if not scope:
+        scope = "default"
+
+    if not USE_FIRESTORE:
+        with _CONFIG_LOCK:
+            return dict(_LOCAL_CONFIG_CACHE.get(scope, {}))
+
+    db = _client()
+    doc = db.collection("watcher_configs").document(scope).get()
+    return doc.to_dict() if doc.exists else {}
+
+
+def upsert_watcher_config(scope: str, data: Dict[str, Any]) -> None:
+    """Persist watcher configuration overrides."""
+
+    if not scope:
+        scope = "default"
+
+    if not USE_FIRESTORE:
+        with _CONFIG_LOCK:
+            existing = dict(_LOCAL_CONFIG_CACHE.get(scope, {}))
+            existing.update(data)
+            _LOCAL_CONFIG_CACHE[scope] = existing
+        return
+
+    db = _client()
+    db.collection("watcher_configs").document(scope).set(data, merge=True)
+
+
+def fetch_notified_matches(scope: str, profile_key: str) -> List[str]:
+    """Read the set of previously notified match ids for a profile."""
+
+    scope = scope or "default"
+    profile_key = profile_key or "unknown"
+
+    if not USE_FIRESTORE:
+        with _CONFIG_LOCK:
+            return list(_LOCAL_NOTIFIED_CACHE.get((scope, profile_key), []))
+
+    db = _client()
+    doc = (
+        db.collection("watcher_state")
+        .document(scope)
+        .collection("profiles")
+        .document(profile_key)
+        .get()
+    )
+    if not doc.exists:
+        return []
+    payload = doc.to_dict() or {}
+    return list(payload.get("notified_match_ids", []))
+
+
+def store_notified_matches(scope: str, profile_key: str, match_ids: List[str]) -> None:
+    """Persist the deduplicated list of match ids already notified."""
+
+    scope = scope or "default"
+    profile_key = profile_key or "unknown"
+    deduped = sorted(set(filter(None, match_ids)))
+
+    if not USE_FIRESTORE:
+        with _CONFIG_LOCK:
+            if deduped:
+                _LOCAL_NOTIFIED_CACHE[(scope, profile_key)] = deduped
+            else:
+                _LOCAL_NOTIFIED_CACHE.pop((scope, profile_key), None)
+        return
+
+    db = _client()
+    doc_ref = (
+        db.collection("watcher_state")
+        .document(scope)
+        .collection("profiles")
+        .document(profile_key)
+    )
+
+    if not deduped:
+        doc_ref.delete()
+        return
+
+    # Lazy import to avoid requiring Firestore when running locally.
+    from google.cloud import firestore as firestore_sdk
+
+    doc_ref.set(
+        {
+            "notified_match_ids": deduped,
+            "updated_at": firestore_sdk.SERVER_TIMESTAMP,
+        },
+        merge=True,
+    )
 
 # -------------------------------
 # Local wrapper for degraded mode

--- a/app/services/notifier.py
+++ b/app/services/notifier.py
@@ -1,0 +1,205 @@
+"""Notification helpers for email/SMS/webhook fan-out.
+
+The notifier is intentionally lightweight – each channel is optional and only
+activated when the required environment variables are supplied.  This keeps
+local development simple (where notifications are logged) while enabling real
+integrations in production environments (SMTP/Twilio/webhook).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import smtplib
+import ssl
+from dataclasses import dataclass, field
+from email.mime.text import MIMEText
+from typing import Any, Dict, List, Optional
+
+import requests
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _split_csv(value: Optional[str]) -> List[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _render_match_summary(matches: List[Dict[str, Any]]) -> str:
+    lines = []
+    for m in matches:
+        name = m.get("other_name") or m.get("other_profile_id") or "Unknown"
+        score = m.get("score")
+        status = m.get("notification_status") or ("new" if m.get("is_new") else "notified")
+        lines.append(f"- {name} (score: {score}, status: {status})")
+    return "\n".join(lines)
+
+
+@dataclass
+class NotificationPayload:
+    scope: str
+    user_profile: Dict[str, Any]
+    matches: List[Dict[str, Any]]
+    rooms: List[Dict[str, Any]]
+    trace: Dict[str, Any]
+    summary: Optional[str] = None
+    subject: Optional[str] = None
+    partner: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class Notifier:
+    """Aggregates all outbound notification channels."""
+
+    def __init__(self) -> None:
+        self.smtp_host = os.getenv("NOTIFIER_SMTP_HOST")
+        self.smtp_port = int(os.getenv("NOTIFIER_SMTP_PORT", "587"))
+        self.smtp_user = os.getenv("NOTIFIER_SMTP_USERNAME")
+        self.smtp_password = os.getenv("NOTIFIER_SMTP_PASSWORD")
+        self.email_sender = os.getenv("NOTIFIER_EMAIL_SENDER")
+
+        self.twilio_account_sid = os.getenv("NOTIFIER_TWILIO_SID")
+        self.twilio_auth_token = os.getenv("NOTIFIER_TWILIO_TOKEN")
+        self.twilio_from_number = os.getenv("NOTIFIER_TWILIO_FROM")
+
+        self.default_webhooks = _split_csv(os.getenv("NOTIFIER_WEBHOOK_URLS"))
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def dispatch(
+        self,
+        payload: NotificationPayload,
+        channels: List[str],
+        partner_webhooks: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Send notifications on the desired channels.
+
+        Returns a map detailing the status of each attempted channel.  Any
+        runtime errors are caught and returned to the caller – the watcher can
+        then record telemetry without the background worker crashing.
+        """
+
+        statuses: Dict[str, Any] = {}
+        rendered_summary = payload.summary or _render_match_summary(payload.matches)
+        subject = payload.subject or f"Room matches for {payload.user_profile.get('name', 'student')}"
+
+        if "email" in channels:
+            statuses["email"] = self._send_email(payload, subject, rendered_summary)
+
+        if "sms" in channels:
+            statuses["sms"] = self._send_sms(payload, rendered_summary)
+
+        if "webhook" in channels:
+            all_hooks = list(self.default_webhooks)
+            if partner_webhooks:
+                all_hooks.extend(partner_webhooks)
+            statuses["webhook"] = self._send_webhooks(payload, rendered_summary, all_hooks)
+
+        return statuses
+
+    # ------------------------------------------------------------------
+    # Email
+    # ------------------------------------------------------------------
+    def _send_email(self, payload: NotificationPayload, subject: str, body: str) -> Dict[str, Any]:
+        recipient = payload.user_profile.get("email")
+        if not (self.smtp_host and self.email_sender and recipient):
+            LOGGER.info("Skipping email notification (missing configuration or recipient).")
+            return {"status": "skipped", "reason": "missing_config_or_recipient"}
+
+        message = MIMEText(
+            f"Hello {payload.user_profile.get('name', 'there')},\n\n"
+            f"Here are your latest roommate matches:\n{body}\n\n"
+            f"Trace id: {payload.trace.get('mode')}\n"
+        )
+        message["Subject"] = subject
+        message["From"] = self.email_sender
+        message["To"] = recipient
+
+        try:
+            context = ssl.create_default_context()
+            with smtplib.SMTP(self.smtp_host, self.smtp_port, timeout=15) as server:
+                server.starttls(context=context)
+                if self.smtp_user and self.smtp_password:
+                    server.login(self.smtp_user, self.smtp_password)
+                server.sendmail(self.email_sender, [recipient], message.as_string())
+            LOGGER.info("Sent email notification to %s", recipient)
+            return {"status": "sent", "recipient": recipient}
+        except Exception as exc:  # pragma: no cover - network errors
+            LOGGER.exception("Failed to send email notification")
+            return {"status": "error", "error": str(exc)}
+
+    # ------------------------------------------------------------------
+    # SMS
+    # ------------------------------------------------------------------
+    def _send_sms(self, payload: NotificationPayload, body: str) -> Dict[str, Any]:
+        recipient = payload.user_profile.get("phone") or payload.user_profile.get("phone_number")
+        if not (self.twilio_account_sid and self.twilio_auth_token and self.twilio_from_number and recipient):
+            LOGGER.info("Skipping SMS notification (missing configuration or recipient).")
+            return {"status": "skipped", "reason": "missing_config_or_recipient"}
+
+        message = f"Matches ready: {body[:140]}"
+        url = f"https://api.twilio.com/2010-04-01/Accounts/{self.twilio_account_sid}/Messages.json"
+        try:
+            response = requests.post(
+                url,
+                auth=(self.twilio_account_sid, self.twilio_auth_token),
+                data={
+                    "From": self.twilio_from_number,
+                    "To": recipient,
+                    "Body": message,
+                },
+                timeout=10,
+            )
+            response.raise_for_status()
+            LOGGER.info("Sent SMS notification to %s", recipient)
+            return {"status": "sent", "recipient": recipient}
+        except Exception as exc:  # pragma: no cover - network errors
+            LOGGER.exception("Failed to send SMS notification")
+            return {"status": "error", "error": str(exc)}
+
+    # ------------------------------------------------------------------
+    # Webhooks
+    # ------------------------------------------------------------------
+    def _send_webhooks(
+        self,
+        payload: NotificationPayload,
+        summary: str,
+        hooks: List[str],
+    ) -> Dict[str, Any]:
+        if not hooks:
+            LOGGER.info("Skipping webhook notification (no endpoints configured).")
+            return {"status": "skipped", "reason": "missing_endpoints"}
+
+        results = []
+        for url in hooks:
+            if not url:
+                continue
+            try:
+                response = requests.post(
+                    url,
+                    json={
+                        "scope": payload.scope,
+                        "user": payload.user_profile,
+                        "matches": payload.matches,
+                        "rooms": payload.rooms,
+                        "summary": summary,
+                        "trace": payload.trace,
+                        "metadata": payload.metadata,
+                    },
+                    timeout=10,
+                )
+                response.raise_for_status()
+                results.append({"status": "sent", "endpoint": url, "code": response.status_code})
+            except Exception as exc:  # pragma: no cover - network errors
+                LOGGER.exception("Failed to send webhook notification to %s", url)
+                results.append({"status": "error", "endpoint": url, "error": str(exc)})
+
+        return {"status": "completed", "results": results}
+
+
+__all__ = ["NotificationPayload", "Notifier"]
+

--- a/app/services/task_queue.py
+++ b/app/services/task_queue.py
@@ -1,0 +1,41 @@
+"""Celery application wiring for background workers.
+
+This module keeps the Celery instance in a single place so that tasks can
+import it without triggering circular imports.  Celery is optional – when the
+``CELERY_BROKER_URL`` environment variable is missing the broker falls back to
+the in-memory transport which is suitable for unit tests.  Production
+deployments should set the broker/backend explicitly (e.g. Redis, Cloud Tasks
+via ``celery-cloud-tasks`` or RabbitMQ).
+"""
+
+from __future__ import annotations
+
+import os
+from celery import Celery
+
+
+def _default_backend() -> str:
+    backend = os.getenv("CELERY_RESULT_BACKEND")
+    if backend:
+        return backend
+    # ``cache+memory://`` keeps things lightweight for local execution and
+    # avoids an RPC backend dependency.
+    return "cache+memory://"
+
+
+celery_app = Celery(
+    "room_matcher",
+    broker=os.getenv("CELERY_BROKER_URL", "memory://"),
+    backend=_default_backend(),
+)
+
+celery_app.conf.update(
+    task_serializer="json",
+    result_serializer="json",
+    accept_content=["json"],
+    timezone=os.getenv("CELERY_TIMEZONE", "UTC"),
+    enable_utc=True,
+)
+
+__all__ = ["celery_app"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ sentence-transformers==3.0.1
 # GCP clients (optional for Firestore/GCS; not required for local run)
 google-cloud-firestore==2.16.0
 google-cloud-storage==2.18.2
+celery==5.4.0
+requests==2.32.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)

--- a/tests/test_pipeline_trace.py
+++ b/tests/test_pipeline_trace.py
@@ -1,0 +1,32 @@
+from app.graph import run_pipeline
+from app.services.firestore import fetch_all_profiles, fetch_all_listings
+
+
+def test_trace_marks_new_vs_notified():
+    profiles = fetch_all_profiles()
+    listings = fetch_all_listings()
+
+    # Use the first profile as the seeker.
+    seeker = profiles[0]
+
+    baseline = run_pipeline(seeker, profiles, listings, top_k=3)
+    assert baseline["matches"], "expected at least one baseline match"
+
+    first_match = baseline["matches"][0]["other_profile_id"]
+
+    rerun = run_pipeline(
+        seeker,
+        profiles,
+        listings,
+        top_k=3,
+        notified_match_ids={first_match},
+    )
+
+    match_statuses = {m["other_profile_id"]: m["notification_status"] for m in rerun["matches"] if m.get("other_profile_id")}
+    assert match_statuses[first_match] == "notified"
+
+    trace_agents = [step["agent"] for step in rerun["trace"]["steps"]]
+    assert "MatchNotifier" in trace_agents
+
+    notifier_step = next(step for step in rerun["trace"]["steps"] if step["agent"] == "MatchNotifier")
+    assert notifier_step["outputs"]["previously_notified"] >= 1

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,0 +1,64 @@
+import pytest
+
+from app.agents.watcher import (
+    WatcherConfig,
+    auto_hunt,
+    get_watcher_config,
+    profile_key,
+    run_auto_hunt_task,
+)
+from app.services.firestore import fetch_all_profiles, fetch_notified_matches, store_notified_matches
+
+
+def test_get_watcher_config_defaults(monkeypatch):
+    monkeypatch.setenv("AUTO_HUNT_DEFAULT_CADENCE_SEC", "120")
+    monkeypatch.setenv("AUTO_HUNT_DEFAULT_MIN_SCORE", "42")
+    monkeypatch.setenv("AUTO_HUNT_DEFAULT_TOP_K", "4")
+    monkeypatch.setenv("AUTO_HUNT_DEFAULT_CHANNELS", "email,sms")
+
+    profile = fetch_all_profiles()[0]
+    cfg = get_watcher_config(profile)
+    assert isinstance(cfg, WatcherConfig)
+    assert cfg.cadence_sec == 120
+    assert cfg.min_score == 42
+    assert cfg.top_k == 4
+    assert cfg.channels == ["email", "sms"]
+
+
+def test_auto_hunt_cycle_updates_notified_cache(monkeypatch):
+    # Force synchronous execution for deterministic tests.
+    monkeypatch.delenv("CELERY_BROKER_URL", raising=False)
+    monkeypatch.setenv("AUTO_HUNT_FORCE_SYNC", "true")
+    monkeypatch.setenv("AUTO_HUNT_DEFAULT_MIN_SCORE", "0")
+
+    seeker = fetch_all_profiles()[0]
+    key = profile_key(seeker)
+    store_notified_matches("default", key, [])
+
+    outcome = auto_hunt(seeker, reschedule=False)
+    assert "result" in outcome
+    assert isinstance(outcome["new_matches"], list)
+    assert len(outcome["new_matches"]) <= len(outcome["result"]["matches"])
+
+    if outcome["new_matches"]:
+        stored = fetch_notified_matches("default", key)
+        notified_ids = {m["other_profile_id"] for m in outcome["new_matches"] if m.get("other_profile_id")}
+        assert set(stored) >= notified_ids
+    else:  # pragma: no cover - dataset should usually yield matches
+        pytest.skip("auto-hunt produced no new matches; unable to verify state persistence")
+
+
+def test_run_auto_hunt_task_respects_reschedule(monkeypatch):
+    monkeypatch.setenv("AUTO_HUNT_FORCE_SYNC", "true")
+    seeker = fetch_all_profiles()[1]
+    key = profile_key(seeker)
+    store_notified_matches("default", key, [])
+
+    outcome = run_auto_hunt_task.run(
+        user_profile=seeker,
+        scope="default",
+        config_override={"cadence_sec": 0, "min_score": 0, "top_k": 2, "channels": []},
+        reschedule=False,
+    )
+
+    assert outcome["config"]["cadence_sec"] == 0


### PR DESCRIPTION
## Summary
- wrap the auto-hunt watcher in a Celery task that reloads per-user configuration and stores notified matches
- add a notifier module with email, SMS, and webhook fan-out plus Firestore-backed watcher configuration/state helpers
- surface configuration knobs and notification trace metadata through run_pipeline, README docs, and regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dd0c21637c8323aaa8d750bf473fca