### PR TITLE
feat: improve deployment observability and warmup

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,12 @@ hand-labelled compatibility targets for the synthetic scenarios. Use these to
 compare configurations between finetuning cycles. Traces capture intermediate
 agent outputs so you can debug why a pair succeeded or failed under a given
 configuration.
+
+---
+
+## 📦 Deployment Operations
+
+An end-to-end Cloud Build → Cloud Run deployment runbook for university and
+partner operators lives in [`docs/deployment.md`](docs/deployment.md). It covers
+secret management, environment configuration, rollout verification (health
+checks, cache warmup script, and log monitoring), plus rollback commands.

--- a/app/graph.py
+++ b/app/graph.py
@@ -77,6 +77,7 @@
 #     return {"mode": mode, "matches": top, "rooms": rooms, "trace": trace}
 
 # app/graph.py
+import uuid
 from typing import List, Dict, Any, Optional, Iterable, Set
 from .agents.profile_reader import normalize_profile
 from .agents.retrieval import CandidateRetrieval, RetrievalConfig
@@ -157,7 +158,9 @@ def run_pipeline(
             return f.get("type")
         return str(f)
 
+    trace_id = uuid.uuid4().hex
     trace = {
+        "trace_id": trace_id,
         "mode": mode,
         "steps": [
             {"agent": "ProfileReader", "inputs": {"fields": list(input_profile.keys())}, "outputs": {"normalized": True}},

--- a/app/main.py
+++ b/app/main.py
@@ -1,181 +1,149 @@
-# # app/main.py
-# import os, time
-# from typing import List, Optional, Dict, Any
-# from fastapi import FastAPI, Header
-# from fastapi.responses import JSONResponse
-# from fastapi.middleware.cors import CORSMiddleware
-# from pydantic import BaseModel
-# from .graph import run_pipeline
-# from .services.firestore import fetch_all_profiles, fetch_all_listings
+import json
+import logging
+import os
+import threading
+import time
+import uuid
+from typing import Any, Dict, List, Optional
 
-# SERVER_DEFAULT_MODE = os.getenv("MODE", "online").lower()
-# FIRESTORE_ENABLED = os.getenv("FIRESTORE_ENABLED", "true").lower() == "true"
-
-# CACHE_TTL_SEC = int(os.getenv("CACHE_TTL_SEC", "120"))
-# _profiles_cache: List[Dict[str, Any]] = []
-# _listings_cache: List[Dict[str, Any]] = []
-# _cache_at: float = 0.0
-# LAST_EFFECTIVE_MODE = SERVER_DEFAULT_MODE
-
-# def _load_cached() -> None:
-#     global _profiles_cache, _listings_cache, _cache_at
-#     now = time.time()
-#     if now - _cache_at < CACHE_TTL_SEC and _profiles_cache and _listings_cache:
-#         return
-#     # Read once (normalized inside fetch_all_*)
-#     _profiles_cache = fetch_all_profiles()
-#     _listings_cache = fetch_all_listings()
-#     _cache_at = now
-
-# def _mode(req_mode: Optional[str], header_mode: Optional[str]) -> str:
-#     global LAST_EFFECTIVE_MODE
-#     m = (req_mode or header_mode or SERVER_DEFAULT_MODE).lower()
-#     if m not in ("online", "degraded"):
-#         m = SERVER_DEFAULT_MODE
-#     LAST_EFFECTIVE_MODE = m
-#     return m
-
-# app = FastAPI(title="Room Matcher AI", version="0.3.0")
-# app.add_middleware(
-#     CORSMiddleware,
-#     allow_origins=["*"],
-#     allow_credentials=False,
-#     allow_methods=["*"],
-#     allow_headers=["*"],
-# )
-
-# class Profile(BaseModel):
-#     id: Optional[str] = None
-#     name: Optional[str] = None
-#     city: Optional[str] = None
-#     budget_pkr: Optional[int] = None
-#     sleep_schedule: Optional[str] = None
-#     cleanliness: Optional[str] = None
-#     noise_tolerance: Optional[str] = None
-#     study_habits: Optional[str] = None
-#     food_pref: Optional[str] = None
-#     smoking: Optional[str] = None
-#     guests_freq: Optional[str] = None
-#     gender_pref: Optional[str] = None
-#     languages: Optional[List[str]] = None
-#     raw_text: Optional[str] = None
-
-# class ParseReq(BaseModel):
-#     text: str
-#     mode: Optional[str] = None
-
-# class MatchTopReq(BaseModel):
-#     profile: Profile
-#     k: int = 5
-#     mode: Optional[str] = None
-
-# class RoomSuggestReq(BaseModel):
-#     city: str
-#     per_person_budget: int
-#     needed_amenities: List[str] = []
-#     mode: Optional[str] = None
-
-# @app.get("/healthz")
-# def healthz():
-#     return {
-#         "status": "ok",
-#         "server_default_mode": SERVER_DEFAULT_MODE,
-#         "last_effective_mode": LAST_EFFECTIVE_MODE,
-#         "firestore_enabled": FIRESTORE_ENABLED,
-#         "project": os.getenv("GCP_PROJECT"),
-#         "profiles_cached": len(_profiles_cache),
-#         "listings_cached": len(_listings_cache),
-#         "cache_age_sec": max(0, int(time.time() - _cache_at)) if _cache_at else None,
-#         "cache_ttl_sec": CACHE_TTL_SEC,
-#     }
-
-# @app.post("/profiles/parse")
-# def parse_profile(req: ParseReq, x_mode: Optional[str] = Header(None)):
-#     mode = _mode(req.mode, x_mode)
-
-#     from .agents.profile_reader import parse_profile_text
-#     prof, conf = parse_profile_text(req.text, mode=mode)
-#     return {"profile": prof, "confidence": conf, "mode_used": mode}
-
-#     try:
-#         from .agents.profile_reader import parse_profile_text
-#         prof, conf = parse_profile_text(req.text or "", mode=mode)
-#         return {"profile": prof, "confidence": conf, "mode_used": mode}
-#     except Exception as e:
-#         # Prevent crash, return fallback
-#         fallback = {
-#             "city": None,
-#             "budget_pkr": None,
-#             "sleep_schedule": None,
-#             "cleanliness": None,
-#             "noise_tolerance": None,
-#             "smoking": None,
-#             "guests_freq": None,
-#             "raw_text": req.text or ""
-#         }
-#         return {
-#             "profile": fallback,
-#             "confidence": 0.0,
-#             "mode_used": mode,
-#             "warning": f"parse_error: {str(e)}"
-#         }
-
-
-
-# @app.post("/match/top")
-# def match_top(req: MatchTopReq, x_mode: Optional[str] = Header(None)):
-#     mode = _mode(req.mode, x_mode)
-#     _load_cached()
-#     result = run_pipeline(
-#         input_profile=req.profile.dict(),
-#         candidates=_profiles_cache,
-#         listings=_listings_cache,
-#         mode=mode,
-#         top_k=req.k
-#     )
-#     return JSONResponse(result)
-
-# @app.post("/rooms/suggest")
-# def rooms_suggest(req: RoomSuggestReq, x_mode: Optional[str] = Header(None)):
-#     mode = _mode(req.mode, x_mode)
-#     _load_cached()
-#     from .agents.room_hunter import suggest_rooms
-#     out = suggest_rooms(req.city, req.per_person_budget, req.needed_amenities, _listings_cache, mode=mode, limit=5)
-#     return {"listings": out, "mode_used": mode}
-
-# app/main.py
-
-import os, time
-from typing import List, Optional, Dict, Any
-from fastapi import FastAPI, Header
-from fastapi.responses import JSONResponse
+from fastapi import FastAPI, Header, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from .graph import run_pipeline
-from .services.firestore import fetch_all_profiles, fetch_all_listings
 from .agents.room_hunter import suggest_rooms
+from .graph import run_pipeline
+from .services.firestore import fetch_all_listings, fetch_all_profiles
 
+PROJECT_ID = os.getenv("GCP_PROJECT") or os.getenv("GOOGLE_CLOUD_PROJECT")
+SERVICE_NAME = os.getenv("SERVICE_NAME", "room-matcher-ai")
+STRUCTURED_LOGGING = os.getenv("ENABLE_STRUCTURED_LOGS", "true").lower() == "true"
+ENABLE_STARTUP_WARMUP = os.getenv("ENABLE_STARTUP_WARMUP", "true").lower() == "true"
+FAISS_ENV_FLAG = os.getenv("FAISS_ENABLED")
+FAISS_ENABLED = (FAISS_ENV_FLAG or "false").lower() == "true"
 
 SERVER_DEFAULT_MODE = os.getenv("MODE", "online").lower()
 FIRESTORE_ENABLED = os.getenv("FIRESTORE_ENABLED", "true").lower() == "true"
-
 CACHE_TTL_SEC = int(os.getenv("CACHE_TTL_SEC", "120"))
+
+logger = logging.getLogger("room-matcher")
+if not logger.handlers:
+    logging.basicConfig(
+        level=os.getenv("LOG_LEVEL", "INFO").upper(),
+        format="%(message)s",
+    )
+logger.setLevel(os.getenv("LOG_LEVEL", "INFO").upper())
+
 _profiles_cache: List[Dict[str, Any]] = []
 _listings_cache: List[Dict[str, Any]] = []
 _cache_at: float = 0.0
 LAST_EFFECTIVE_MODE = SERVER_DEFAULT_MODE
+_CACHE_LOCK = threading.Lock()
+_METRICS_LOCK = threading.Lock()
+_REQUEST_METRICS: Dict[str, Any] = {
+    "total_requests": 0,
+    "total_errors": 0,
+    "total_latency_ms": 0.0,
+    "max_latency_ms": 0.0,
+    "last_request_ts": None,
+}
+_LAST_WARMUP: float = 0.0
+_FAISS_STORE: Optional[Any] = None
 
 
-# ---------------- Cache helpers ----------------
-def _load_cached() -> None:
+def _emit_log(level: int, event: str, trace_id: Optional[str] = None, **payload: Any) -> None:
+    entry: Dict[str, Any] = {
+        "event": event,
+        "service": SERVICE_NAME,
+        **{k: v for k, v in payload.items() if v is not None},
+    }
+    if trace_id:
+        entry["trace_id"] = trace_id
+        if PROJECT_ID:
+            entry["logging.googleapis.com/trace"] = f"projects/{PROJECT_ID}/traces/{trace_id}"
+    try:
+        if STRUCTURED_LOGGING:
+            logger.log(level, json.dumps(entry, default=str))
+        else:
+            logger.log(level, "%s %s", event, entry)
+    except Exception:  # pragma: no cover - fallback safeguard
+        logger.log(level, "%s %s", event, entry)
+
+
+def _record_metrics(duration_ms: float, status_code: int) -> None:
+    with _METRICS_LOCK:
+        _REQUEST_METRICS["total_requests"] += 1
+        _REQUEST_METRICS["total_latency_ms"] += duration_ms
+        _REQUEST_METRICS["max_latency_ms"] = max(_REQUEST_METRICS["max_latency_ms"], duration_ms)
+        _REQUEST_METRICS["last_request_ts"] = time.time()
+        if status_code >= 500:
+            _REQUEST_METRICS["total_errors"] += 1
+
+
+def _metrics_snapshot() -> Dict[str, Any]:
+    with _METRICS_LOCK:
+        total = _REQUEST_METRICS["total_requests"]
+        avg_latency = _REQUEST_METRICS["total_latency_ms"] / total if total else 0.0
+        return {
+            "total_requests": total,
+            "total_errors": _REQUEST_METRICS["total_errors"],
+            "avg_latency_ms": round(avg_latency, 2),
+            "max_latency_ms": round(_REQUEST_METRICS["max_latency_ms"], 2),
+            "last_request_ts": _REQUEST_METRICS["last_request_ts"],
+        }
+
+
+def _warmup_faiss() -> bool:
+    global _FAISS_STORE
+    if not FAISS_ENABLED:
+        return False
+    if _FAISS_STORE and getattr(_FAISS_STORE, "ready", lambda: False)():
+        return True
+    try:
+        from .services.faiss_store import FaissStore
+    except Exception as exc:  # pragma: no cover - defensive import guard
+        _emit_log(logging.WARNING, "faiss_import_failed", error=str(exc))
+        return False
+    try:
+        store = FaissStore()
+    except Exception as exc:  # pragma: no cover - FAISS optional
+        _emit_log(logging.WARNING, "faiss_initialization_failed", error=str(exc))
+        return False
+    if store.ready():
+        _FAISS_STORE = store
+        index_size = getattr(getattr(store, "index", None), "ntotal", None)
+        _emit_log(logging.INFO, "faiss_index_warmed", index_size=index_size)
+        return True
+    _emit_log(logging.WARNING, "faiss_index_unavailable")
+    return False
+
+
+def _load_cached(force: bool = False) -> None:
     global _profiles_cache, _listings_cache, _cache_at
     now = time.time()
-    if now - _cache_at < CACHE_TTL_SEC and _profiles_cache and _listings_cache:
-        return
-    _profiles_cache = fetch_all_profiles()
-    _listings_cache = fetch_all_listings()
-    _cache_at = now
+    with _CACHE_LOCK:
+        if not force and now - _cache_at < CACHE_TTL_SEC and _profiles_cache and _listings_cache:
+            return
+        _profiles_cache = fetch_all_profiles()
+        _listings_cache = fetch_all_listings()
+        _cache_at = time.time()
+
+
+def warmup_caches(force: bool = False) -> Dict[str, Any]:
+    global _LAST_WARMUP
+    started = time.time()
+    _load_cached(force=force)
+    faiss_ready = _warmup_faiss()
+    duration_ms = (time.time() - started) * 1000.0
+    _LAST_WARMUP = time.time()
+    snapshot = {
+        "duration_ms": round(duration_ms, 2),
+        "profiles_cached": len(_profiles_cache),
+        "listings_cached": len(_listings_cache),
+        "faiss_ready": faiss_ready,
+    }
+    _emit_log(logging.INFO, "cache_warmup_completed", **snapshot)
+    return snapshot
 
 
 def _mode(req_mode: Optional[str], header_mode: Optional[str]) -> str:
@@ -187,8 +155,7 @@ def _mode(req_mode: Optional[str], header_mode: Optional[str]) -> str:
     return m
 
 
-# ---------------- FastAPI app ----------------
-app = FastAPI(title="Room Matcher AI", version="0.4.0")
+app = FastAPI(title="Room Matcher AI", version="0.5.0")
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -198,7 +165,57 @@ app.add_middleware(
 )
 
 
-# ---------------- Models ----------------
+@app.middleware("http")
+async def structured_logging_middleware(request: Request, call_next):
+    request_id = uuid.uuid4().hex
+    request.state.request_id = request_id
+    start = time.perf_counter()
+    try:
+        response = await call_next(request)
+        status_code = response.status_code
+    except Exception as exc:
+        duration_ms = (time.perf_counter() - start) * 1000.0
+        _record_metrics(duration_ms, 500)
+        _emit_log(
+            logging.ERROR,
+            "request_failed",
+            request_id=request_id,
+            path=request.url.path,
+            method=request.method,
+            duration_ms=round(duration_ms, 2),
+            error=str(exc),
+            user_agent=request.headers.get("user-agent"),
+        )
+        raise
+    duration_ms = (time.perf_counter() - start) * 1000.0
+    _record_metrics(duration_ms, status_code)
+    response.headers["X-Request-Id"] = request_id
+    response.headers["X-Response-Time-Ms"] = f"{duration_ms:.2f}"
+    _emit_log(
+        logging.INFO,
+        "request_completed",
+        request_id=request_id,
+        path=request.url.path,
+        method=request.method,
+        status_code=status_code,
+        duration_ms=round(duration_ms, 2),
+        mode=LAST_EFFECTIVE_MODE,
+        user_agent=request.headers.get("user-agent"),
+    )
+    return response
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    if not ENABLE_STARTUP_WARMUP:
+        _emit_log(logging.INFO, "startup_warmup_skipped")
+        return
+    try:
+        warmup_caches(force=True)
+    except Exception as exc:  # pragma: no cover - startup defensive log
+        _emit_log(logging.ERROR, "startup_warmup_failed", error=str(exc))
+
+
 class Profile(BaseModel):
     id: Optional[str] = None
     name: Optional[str] = None
@@ -239,7 +256,6 @@ class RoomSuggestReq(BaseModel):
     geo: Optional[Dict[str, Any]] = None
 
 
-# ---------------- Endpoints ----------------
 @app.get("/healthz")
 def healthz():
     return {
@@ -247,52 +263,37 @@ def healthz():
         "server_default_mode": SERVER_DEFAULT_MODE,
         "last_effective_mode": LAST_EFFECTIVE_MODE,
         "firestore_enabled": FIRESTORE_ENABLED,
-        "project": os.getenv("GCP_PROJECT"),
+        "project": PROJECT_ID,
         "profiles_cached": len(_profiles_cache),
         "listings_cached": len(_listings_cache),
         "cache_age_sec": max(0, int(time.time() - _cache_at)) if _cache_at else None,
         "cache_ttl_sec": CACHE_TTL_SEC,
+        "metrics": _metrics_snapshot(),
+        "last_warmup_at": _LAST_WARMUP or None,
+        "faiss_enabled": FAISS_ENABLED,
     }
 
 
 @app.post("/profiles/parse")
-def parse_profile(req: ParseReq, x_mode: Optional[str] = Header(None)):
-    """Parse freeform roommate text into structured attributes.
-
-    Example response::
-
-        {
-            "profile": {
-                "city": "Lahore",
-                "budget_pkr": 35000,
-                "sleep_schedule": "night_owl",
-                "cleanliness": "medium",
-                "noise_tolerance": "medium",
-                "smoking": "no",
-                "guests_freq": "sometimes",
-                "role": "student",
-                "languages": ["en", "ur"],
-                "raw_text": "..."
-            },
-            "confidence": 0.72,
-            "mode_used": "online"
-        }
-
-    Confidence is a heuristic between 0 and 1 describing how sure the parser is
-    about the extracted attributes.
-    """
+def parse_profile(req: ParseReq, request: Request, x_mode: Optional[str] = Header(None)):
+    """Parse freeform roommate text into structured attributes."""
     mode = _mode(req.mode, x_mode)
     from .agents.profile_reader import parse_profile_text
+
     prof, conf = parse_profile_text(req.text, mode=mode)
+    _emit_log(
+        logging.INFO,
+        "profile_parsed",
+        request_id=getattr(request.state, "request_id", None),
+        mode=mode,
+        confidence=round(conf, 4),
+    )
     return {"profile": prof, "confidence": conf, "mode_used": mode}
 
 
 @app.post("/match/top")
-def match_top(req: MatchTopReq, x_mode: Optional[str] = Header(None)):
-    """
-    Full pipeline: parse profile → retrieval → scoring → red flags → wingman → room hunter → maps planner
-    Returns matches + enriched room suggestions.
-    """
+def match_top(req: MatchTopReq, request: Request, x_mode: Optional[str] = Header(None)):
+    """Full pipeline returning matches and enriched room suggestions."""
     mode = _mode(req.mode, x_mode)
     _load_cached()
     result = run_pipeline(
@@ -300,13 +301,23 @@ def match_top(req: MatchTopReq, x_mode: Optional[str] = Header(None)):
         candidates=_profiles_cache,
         listings=_listings_cache,
         mode=mode,
-        top_k=req.k
+        top_k=req.k,
+    )
+    trace_id = (result.get("trace") or {}).get("trace_id")
+    _emit_log(
+        logging.INFO,
+        "pipeline_completed",
+        request_id=getattr(request.state, "request_id", None),
+        mode=mode,
+        matches=len(result.get("matches", [])),
+        rooms=len(result.get("rooms", [])),
+        trace_id=trace_id,
     )
     return JSONResponse(result)
 
 
 @app.post("/rooms/suggest")
-def rooms_suggest(req: RoomSuggestReq, x_mode: Optional[str] = Header(None)):
+def rooms_suggest(req: RoomSuggestReq, request: Request, x_mode: Optional[str] = Header(None)):
     mode = _mode(req.mode, x_mode)
     _load_cached()
     out = suggest_rooms(
@@ -319,4 +330,23 @@ def rooms_suggest(req: RoomSuggestReq, x_mode: Optional[str] = Header(None)):
         anchor_location=req.anchor_location,
         user_geo=req.geo,
     )
+    _emit_log(
+        logging.INFO,
+        "room_suggestions_completed",
+        request_id=getattr(request.state, "request_id", None),
+        mode=mode,
+        listings=len(out),
+    )
     return {"listings": out, "mode_used": mode}
+
+
+@app.post("/__internal/warmup")
+def manual_warmup(request: Request):
+    stats = warmup_caches(force=True)
+    _emit_log(
+        logging.INFO,
+        "manual_warmup_triggered",
+        request_id=getattr(request.state, "request_id", None),
+        **stats,
+    )
+    return {"status": "ok", **stats}

--- a/app/services/firestore.py
+++ b/app/services/firestore.py
@@ -4,7 +4,14 @@ from typing import List, Dict, Optional, Tuple, Any
 from app.agents.profile_reader import normalize_profile
 
 USE_FIRESTORE = os.getenv("FIRESTORE_ENABLED", "false").lower() == "true"
-PROJECT_ID = os.getenv("GCP_PROJECT")
+PROJECT_ID = os.getenv("GCP_PROJECT") or os.getenv("GOOGLE_CLOUD_PROJECT")
+_CREDENTIALS_PATH = os.getenv("FIRESTORE_CREDENTIALS")
+
+if _CREDENTIALS_PATH and os.path.exists(_CREDENTIALS_PATH):
+    # Surface the secret-based credentials to the Google client libraries.  When
+    # Cloud Run injects a secret via --set-secrets the environment variable
+    # points to a file path containing the JSON payload.
+    os.environ.setdefault("GOOGLE_APPLICATION_CREDENTIALS", _CREDENTIALS_PATH)
 
 _CONFIG_LOCK = threading.Lock()
 _LOCAL_CONFIG_CACHE: Dict[str, Dict[str, Any]] = {}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,11 +1,51 @@
+options:
+  substitution_option: 'ALLOW_LOOSE'
+
+substitutions:
+  _REGION: asia-south1
+  _SERVICE_NAME: room-matcher-ai
+  _MODE: online
+  _FIRESTORE_ENABLED: 'true'
+  _CACHE_TTL_SEC: '300'
+
+availableSecrets:
+  secretManager:
+    - versionName: projects/$PROJECT_ID/secrets/firestore-service-account/versions/latest
+      env: FIRESTORE_CREDENTIALS_SECRET
+    - versionName: projects/$PROJECT_ID/secrets/faiss-availability/versions/latest
+      env: FAISS_ENABLED_SECRET
+
 steps:
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build','-t','asia-south1-docker.pkg.dev/$PROJECT_ID/rm-repo/room-matcher-ai:$COMMIT_SHA','.']
+    args:
+      - build
+      - '-t'
+      - 'asia-south1-docker.pkg.dev/$PROJECT_ID/rm-repo/${_SERVICE_NAME}:$COMMIT_SHA'
+      - '.'
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['push','asia-south1-docker.pkg.dev/$PROJECT_ID/rm-repo/room-matcher-ai:$COMMIT_SHA']
+    args:
+      - push
+      - 'asia-south1-docker.pkg.dev/$PROJECT_ID/rm-repo/${_SERVICE_NAME}:$COMMIT_SHA'
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    args: ['gcloud','run','deploy','room-matcher-ai',
-           '--image=asia-south1-docker.pkg.dev/$PROJECT_ID/rm-repo/room-matcher-ai:$COMMIT_SHA',
-           '--region=asia-south1','--allow-unauthenticated']
+    entrypoint: bash
+    env:
+      - 'MODE=${_MODE}'
+      - 'FIRESTORE_ENABLED=${_FIRESTORE_ENABLED}'
+      - 'CACHE_TTL_SEC=${_CACHE_TTL_SEC}'
+    secretEnv:
+      - FIRESTORE_CREDENTIALS_SECRET
+      - FAISS_ENABLED_SECRET
+    args:
+      - -c
+      - |
+        gcloud run deploy ${_SERVICE_NAME} \
+          --image=asia-south1-docker.pkg.dev/$PROJECT_ID/rm-repo/${_SERVICE_NAME}:$COMMIT_SHA \
+          --region=${_REGION} \
+          --allow-unauthenticated \
+          --set-env-vars=MODE=${MODE},FIRESTORE_ENABLED=${FIRESTORE_ENABLED},CACHE_TTL_SEC=${CACHE_TTL_SEC},ENABLE_STARTUP_WARMUP=true \
+          --set-secrets=FIRESTORE_CREDENTIALS=firestore-service-account:latest,FAISS_ENABLED=faiss-availability:latest \
+          --health-check-path=/healthz \
+          --min-instances=1 \
+          --max-instances=3
 images:
-  - 'asia-south1-docker.pkg.dev/$PROJECT_ID/rm-repo/room-matcher-ai:$COMMIT_SHA'
+  - 'asia-south1-docker.pkg.dev/$PROJECT_ID/rm-repo/${_SERVICE_NAME}:$COMMIT_SHA'

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,87 @@
+# Room Matcher AI Deployment Guide
+
+This runbook documents how university and partner operations teams promote new
+versions of the Room Matcher AI service to Google Cloud Run using Cloud Build.
+It covers the automated trigger, secrets and configuration, rollout checks, and
+rollback guidance.
+
+## 1. Prerequisites
+
+- Google Cloud project with the `room-matcher-ai` artifact repository and Cloud
+  Run service provisioned.
+- Cloud Build service account granted the following roles:
+  - `roles/run.admin`
+  - `roles/secretmanager.secretAccessor`
+  - `roles/artifactregistry.writer`
+- Secret Manager entries populated:
+  - `firestore-service-account` – JSON service account key with access to
+    Firestore.
+  - `faiss-availability` – string flag (`true`/`false`) toggling semantic FAISS
+    retrieval.
+- Optional: configure a Cloud Build substitution `_MODE` when running manual
+  builds to override the default deployment mode (`online`).
+
+## 2. Cloud Build Trigger
+
+1. Push the desired commit to the configured Git branch (typically `main`).
+2. Cloud Build executes `cloudbuild.yaml` which:
+   - Builds and pushes the container image to
+     `asia-south1-docker.pkg.dev/<PROJECT_ID>/rm-repo/room-matcher-ai` tagged
+     with the commit SHA.
+   - Deploys the new revision to Cloud Run with
+     `MODE`, `FIRESTORE_ENABLED`, `CACHE_TTL_SEC`, and `ENABLE_STARTUP_WARMUP`
+     environment variables, and mounts `FIRESTORE_CREDENTIALS` and
+     `FAISS_ENABLED` from Secret Manager.
+   - Enables proactive health checks by configuring the `/healthz` endpoint and
+     keeps one instance warm (`--min-instances=1`).
+
+### Manual trigger
+
+```bash
+gcloud builds submit --config cloudbuild.yaml --substitutions=_MODE=degraded
+```
+
+## 3. Post-deploy Verification
+
+1. Confirm the service revision is ready:
+   ```bash
+   gcloud run services describe room-matcher-ai \
+     --region=asia-south1 --format='value(status.latestReadyRevisionName)'
+   ```
+2. Hit the health endpoint which now exposes cache statistics and request
+   metrics:
+   ```bash
+   curl https://<service-url>/healthz | jq
+   ```
+   Check for `status: ok`, `faiss_enabled`, cache counts, and `metrics` totals.
+3. Warm the caches to ensure low-latency responses using the provided helper:
+   ```bash
+   python scripts/warm_cache.py --url https://<service-url>
+   ```
+   The script POSTs to `/__internal/warmup` which triggers Firestore/JSON cache
+   hydration and optional FAISS loading. Successful runs emit structured JSON
+   summarising cache counts and warmup duration.
+4. Tail structured logs and ensure request metrics increment when hitting test
+   endpoints:
+   ```bash
+   gcloud logs tail --project <PROJECT_ID> --format=json --log-filter='resource.type="cloud_run_revision"'
+   ```
+
+## 4. Rollback Procedure
+
+If issues are detected:
+
+1. Identify the last known-good revision:
+   ```bash
+   gcloud run revisions list --service room-matcher-ai --region=asia-south1
+   ```
+2. Roll back by redeploying the prior revision:
+   ```bash
+   gcloud run services update-traffic room-matcher-ai \
+     --region=asia-south1 --to-revisions <REVISION_NAME>=100
+   ```
+3. Re-run the verification checklist (health check, warmup script, log tailing)
+   to confirm stability.
+
+Document any incidents and configuration tweaks in the shared operations log so
+future rollouts incorporate the learnings.

--- a/scripts/warm_cache.py
+++ b/scripts/warm_cache.py
@@ -1,0 +1,63 @@
+"""Utility to warm Room Matcher AI caches after deployment.
+
+Usage::
+
+    python scripts/warm_cache.py --url https://<service-url>
+
+The script hits the internal warmup endpoint and emits a summary that can be
+captured by Cloud Build or run manually by operators.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any, Dict
+
+import requests
+
+DEFAULT_TIMEOUT = 30
+
+
+def _log(message: str, payload: Dict[str, Any]) -> None:
+    print(f"{message}: {json.dumps(payload, default=str)}")
+
+
+def warm_cache(base_url: str, timeout: int = DEFAULT_TIMEOUT) -> Dict[str, Any]:
+    start = time.time()
+    endpoint = base_url.rstrip("/") + "/__internal/warmup"
+    response = requests.post(endpoint, timeout=timeout)
+    response.raise_for_status()
+    payload = response.json()
+    payload["roundtrip_ms"] = round((time.time() - start) * 1000, 2)
+    return payload
+
+
+def main(argv: Any = None) -> int:
+    parser = argparse.ArgumentParser(description="Warm Room Matcher AI caches")
+    parser.add_argument("--url", default=os.getenv("ROOM_MATCHER_URL"), help="Base URL for the deployed service")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help="HTTP timeout in seconds")
+    args = parser.parse_args(argv)
+
+    if not args.url:
+        print("error: service URL must be provided via --url or ROOM_MATCHER_URL", file=sys.stderr)
+        return 2
+
+    try:
+        summary = warm_cache(args.url, timeout=args.timeout)
+    except requests.HTTPError as exc:
+        print(f"warmup failed with status {exc.response.status_code}: {exc}", file=sys.stderr)
+        if exc.response is not None:
+            print(exc.response.text, file=sys.stderr)
+        return 1
+    except Exception as exc:  # pragma: no cover - network variability
+        print(f"warmup failed: {exc}", file=sys.stderr)
+        return 1
+
+    _log("warmup_succeeded", summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pipeline_trace.py
+++ b/tests/test_pipeline_trace.py
@@ -30,3 +30,4 @@ def test_trace_marks_new_vs_notified():
 
     notifier_step = next(step for step in rerun["trace"]["steps"] if step["agent"] == "MatchNotifier")
     assert notifier_step["outputs"]["previously_notified"] >= 1
+    assert rerun["trace"].get("trace_id"), "expected pipeline trace to include a stable trace_id"


### PR DESCRIPTION
## Summary
- parameterize the Cloud Run deployment in `cloudbuild.yaml` with substitutions, Secret Manager bindings, and health check settings
- add structured logging, request metrics, cache warmup flows, and manual warmup endpoint so trace IDs flow from the pipeline
- document the deployment workflow for operators and ship a helper script to warm caches after rollout

## Testing
- pytest tests/test_pipeline_trace.py

------
https://chatgpt.com/codex/tasks/task_b_68dd161f37a88323ba343b9758314827