### PR TITLE
Fix widget mount entry casing

### DIFF
--- a/frontend/widget/src/mount.tsx
+++ b/frontend/widget/src/mount.tsx
@@ -1,4 +1,4 @@
-// frontend/widget/src/Mount.tsx
+// frontend/widget/src/mount.tsx
 import React from "react";
 import ReactDOM from "react-dom/client";
 import RoomMatcherWidget, { RoomMatcherWidgetProps } from "./RoomMatcherWidget";


### PR DESCRIPTION
## Summary
- rename the widget mount entry file to match the lowercase path expected by Vite

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68de1833cf108323a8a57cc5e15b1f19